### PR TITLE
Adapt style guide, update role meta parameters and fix CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
 ## Description
 
-Please include a summary of the change and which issue is fixed. Please provide the motivation for why this change is necessary at this stage of the product development cycle.
+Please include a summary of the changes and which issue is fixed. Describe the
+rational why the changes are required at this stage.
 
 Fixes # (issue)
 
-## Depedencies
+## Dependencies
 
 Does this PR depend on other PRs of this or a related repository?
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+
       - name: Lint with ansible-lint including yamllint
         run: |
           ansible-lint
+
       - name: Test with molecule
         run: |
           molecule test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role - Potos Wallpaper
 
-A role to set a custom wallpaper
+Role to manage wallpapers of Potos Linux Clients.
 
 [![Test](https://github.com/projectpotos/ansible-role-potos_wallpaper/actions/workflows/test.yml/badge.svg)](https://github.com/projectpotos/ansible-role-potos_wallpaper/actions/workflows/test.yml)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 
-# List of files to be found under `potos_wallpaper` to be added as background, first element is set as default
+# List of files to be found under `potos_wallpaper` to be added as background,
+# first element is set as default
 potos_wallpaper_images = []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,4 @@
---
+---
 
 galaxy_info:
   author: Project Potos

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,18 +1,21 @@
 --
 
-dependencies: []
-
 galaxy_info:
-  role_name: 'potos_wallpaper'
-  author: 'Adfinis AG'
-  description: 'This role is used to set the wallpaper of potos clients'
-  company: 'Adfinis AG'
-  license: 'GNU General Public License v3'
-  min_ansible_version: '2.12.0'
+  author: Project Potos
+  description: Role to manage wallpapers of Potos Linux Clients.
+  company: Project Potos
+  role_name: potos_wallpaper
+  namespace: projectpotos
+  license: GPL-3.0-only
+  min_ansible_version: '2.12'
+
   platforms:
     - name: Ubuntu
       versions:
-        - focal
         - jammy
+
   galaxy_tags:
-    - "potos"
+    - potos
+    - wallpaper
+
+dependencies: []

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,0 @@
----
-
-requires_ansible: '>=2.12'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,4 +5,4 @@
   gather_facts: yes
 
   roles:
-    - role: potos_wallpaper
+    - role: ./

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,7 +5,7 @@
   gather_facts: no
 
   tasks:
-  - name: check if some background exists
+  - name: check if some wallpapers exists
     ansible.builtin.shell:
       cmd: ls -p /usr/share/backgrounds | grep -v / | wc -l
     register: out

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,39 +1,45 @@
 ---
 
-- name: Get os specific facts
-  ansible.builtin.include_vars: "{{ item }}"
+- name: get os specific facts
+  ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_distribution }}.yml'
     - '{{ ansible_os_family }}.yml'  
 
-- name: get Wallpapers to remove
+- name: get wallpapers to remove
   ansible.builtin.shell:
-    cmd: "ls -p /usr/share/backgrounds | grep -v"
+    cmd: ls -p /usr/share/backgrounds | grep -v
   register: potos_wallpaper_backgrounds
   changed_when: false
 
-- name: remove Wallpapers
+- name: remove wallpapers
   ansible.builtin.file:
-    path: "/usr/share/backgrounds/{{ item }}"
+    path: '/usr/share/backgrounds/{{ item }}'
     state: absent
-  loop: "{{ potos_wallpaper_backgrounds | difference( potos_wallpaper_images ) }}"
+  loop: '{{ potos_wallpaper_backgrounds | difference( potos_wallpaper_images ) }}'
 
-- name: Install custom default background
+- name: install custom default background
   ansible.builtin.copy:
-    src: "potos_wallpaper/{{ potos_wallpaper_images[0] }}"
-    dest: "/usr/share/backgrounds/{{ potos_wallpaper_default_name }}"
+    src: 'potos_wallpaper/{{ potos_wallpaper_images[0] }}'
+    dest: '/usr/share/backgrounds/{{ potos_wallpaper_default_name }}'
     owner: root
     group: root
-    mode: "0755"
-  when: potos_wallpaper_default_name is defined and potos_wallpaper_image is iterable and potos_wallpaper is not string and (potos_wallpaper_images | length > 0)
+    mode: 0755
+  when: potos_wallpaper_default_name is defined and
+        potos_wallpaper_image is iterable and
+        potos_wallpaper is not string and
+        (potos_wallpaper_images | length > 0)
 
-- name: Install custom backgrounds
+- name: install custom backgrounds
   ansible.builtin.copy:
-    src: "potos_wallpaper/{{ item }}"
-    dest: "/usr/share/backgrounds/{{ item | basename }}"
+    src: 'potos_wallpaper/{{ item }}'
+    dest: '/usr/share/backgrounds/{{ item | basename }}'
     owner: root
     group: root
-    mode: "0755"
-  loop: "{{ potos_wallpaper_images[1:] | default([]) }}"
-  when: potos_wallpaper_default_name is defined and potos_wallpaper_image is iterable and potos_wallpaper is not string and (potos_wallpaper_images | length > 0)
+    mode: 0755
+  loop: '{{ potos_wallpaper_images[1:] | default([]) }}'
+  when: potos_wallpaper_default_name is defined and
+        potos_wallpaper_image is iterable and
+        potos_wallpaper is not string and
+        (potos_wallpaper_images | length > 0)

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,3 +1,3 @@
 ---
 
-potos_wallpaper_default_name: "warty-final-ubuntu.png"
+potos_wallpaper_default_name: 'warty-final-ubuntu.png'


### PR DESCRIPTION
## Description

This is a small quality of life PR to align the Ansible code with our style guide, update the meta data, fix CI and some other small chores.

The rational behind dropping `focal` is that it would impose supporting a much older Ansible version (i.e. `2.9` which is available in the upstream repos).

## Dependencies

n/a
